### PR TITLE
feat: Introduce IntoCStr trait

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,11 +1,18 @@
 workspace := "~/libnv-rs"
 ubuntu_host := "zetta-ubuntu"
+freebsd_host := "zetta-freebsd13"
 rsync_exclude := "--exclude .git --exclude .idea --exclude target --exclude libzfs_core-sys/target"
 
 set positional-arguments
+
 test-ubuntu args='':
     just copy-code-to {{ubuntu_host}}
     ssh {{ubuntu_host}} '. "$HOME/.cargo/env";cd {{workspace}} && cargo test --no-default-features --features nvpair {{args}}'
+
+
+test-freebsd args='':
+    just copy-code-to {{freebsd_host}}
+    ssh {{freebsd_host}} '. "$HOME/.cargo/env";cd {{workspace}} && cargo test --no-default-features --features libnv {{args}}'
 
 copy-code-to host:
  rsync -az -e "ssh" {{rsync_exclude}} --progress ./ {{host}}:{{workspace}}

--- a/libnv-sys/build.rs
+++ b/libnv-sys/build.rs
@@ -2,14 +2,8 @@ extern crate regex;
 
 #[cfg(target_os = "freebsd")]
 fn main() {
-
     use regex::Regex;
-    use std::{
-        env,
-        fs::File,
-        io::Write,
-        path::PathBuf,
-    };
+    use std::{env, fs::File, io::Write, path::PathBuf};
 
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG_PATH");
     println!("cargo:rustc-link-lib=nv");
@@ -44,17 +38,16 @@ fn main() {
         let new_fragment = match cap.get(1).unwrap().as_str() {
             "fn" => {
                 let funcname = cap.get(2).unwrap().as_str();
-                fixed_bindings.push_str(
-                    &format!("#[link_name = \"FreeBSD_{}\"]\n", funcname));
+                fixed_bindings.push_str(&format!("#[link_name = \"FreeBSD_{}\"]\n", funcname));
                 format!("pub fn {}", funcname)
             },
             "type" => {
                 let typename = cap.get(2).unwrap().as_str();
-                fixed_bindings.push_str(&format!("pub type FreeBSD_{} = {};\n",
-                                                 typename, typename));
+                fixed_bindings
+                    .push_str(&format!("pub type FreeBSD_{} = {};\n", typename, typename));
                 format!("pub type {}", typename)
-            }
-            _ => unreachable!()
+            },
+            _ => unreachable!(),
         };
         fixed_bindings.push_str(&new_fragment);
         prev_index = index + new_fragment.len() + "FreeBSD_".len();

--- a/libnv-sys/src/lib.rs
+++ b/libnv-sys/src/lib.rs
@@ -4,9 +4,8 @@
 //! These are raw, `unsafe` FFI bindings.  Here be dragons!  You probably
 //! shouldn't use this crate directly.  Instead, you should use the
 //! [`libnv`](https://crates.io/crates/libnv) crate.
-#![cfg_attr(crossdocs, doc="")]
-#![cfg_attr(crossdocs, doc="These docs are just stubs!  Don't trust them.")]
-
+#![cfg_attr(crossdocs, doc = "")]
+#![cfg_attr(crossdocs, doc = "These docs are just stubs!  Don't trust them.")]
 // bindgen generates some unconventional type names
 #![allow(non_camel_case_types)]
 

--- a/src/nvpair.rs
+++ b/src/nvpair.rs
@@ -943,7 +943,7 @@ mod test {
         list.insert(owned, 1u32).unwrap();
 
         let borrowed_name = CString::new("borrowed").unwrap();
-        let borrowed = unsafe { CStr::from_ptr(borrowed_name.as_ptr()) };
+        let borrowed: &CStr = borrowed_name.as_c_str();
         list.insert(borrowed, 2u32).unwrap();
 
         let mut expected_map = HashMap::with_capacity(3);


### PR DESCRIPTION
Make public interface more ergonomic by accepting more than just `&str`
in public interface.

BREAKING CHANGE: Public interface now uses generic type that implements
`IntoCStr` instead of `&str` as its input. Function signatures has
changed, but code should work as is.

BREAKING CHANGE: `libnv::insert_strings` now takes ownership of the
value and no longer panics if conversion failed. From now on, it will
return first error as a result.

Closes https://github.com/Inner-Heaven/libnv-rs/issues/18