### PR TITLE
Use native CStr literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libnv"
+edition = "2021"
 version = "0.4.3"
 authors = ["Andrey Snow <andoriyu@gmail.com>"]
 categories = ["api-bindings", "data-structures", "os"]

--- a/src/libnv.rs
+++ b/src/libnv.rs
@@ -29,9 +29,8 @@ use std::{
     os::unix::io::AsRawFd,
     slice,
 };
-use IntoCStr;
 
-use crate::{NvError, NvResult};
+use crate::{IntoCStr, NvError, NvResult};
 
 /// Enumeration of available data types that the API supports.
 pub enum NvType {
@@ -562,8 +561,7 @@ impl NvList {
     ///
     /// list.insert_bool("Did history start on 1776?", true).unwrap();
     ///
-    /// assert!(list.get_bool("Did history start on 1776?").unwrap().unwrap(),
-    /// true);
+    /// assert!(list.get_bool("Did history start on 1776?").unwrap().unwrap());
     /// ```
     pub fn get_bool<'a, N: IntoCStr<'a>>(&self, name: N) -> NvResult<Option<bool>> {
         let c_name = name.into_c_str()?;

--- a/src/nvpair.rs
+++ b/src/nvpair.rs
@@ -1,13 +1,13 @@
 //! Solaris implementation of Name/Value pairs library.
 
-use {nvpair_sys as sys, IntoCStr};
+use nvpair_sys as sys;
 
-use crate::{NvError, NvResult};
+use crate::{IntoCStr, NvError, NvResult};
 use std::os::unix::io::AsRawFd;
 use std::{
     collections::HashMap,
     convert::TryInto,
-    ffi::{CStr, CString},
+    ffi::CStr,
     fmt::Formatter,
     mem::MaybeUninit,
     ptr::null_mut,
@@ -469,7 +469,7 @@ impl NvList {
 
     /// Turn NvPair into json representation. This method uses libnvpair to do so.
     pub fn save_as_json<F: AsRawFd>(&self, output: F) -> NvResult<()> {
-        let mode = CString::new("w").unwrap();
+        let mode = c"w";
         let file = unsafe { libc::fdopen(output.as_raw_fd(), mode.as_ptr()) };
         let errno = unsafe { nvlist_print_json(file, self.ptr) };
         if errno != 0 {
@@ -639,6 +639,7 @@ impl<'a> Iterator for NvListIter<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
     fn it_works() {
@@ -942,8 +943,7 @@ mod test {
         let mut list = NvList::new(NvFlag::UniqueNameType).unwrap();
         list.insert(owned, 1u32).unwrap();
 
-        let borrowed_name = CString::new("borrowed").unwrap();
-        let borrowed: &CStr = borrowed_name.as_c_str();
+        let borrowed = c"borrowed";
         list.insert(borrowed, 2u32).unwrap();
 
         let mut expected_map = HashMap::with_capacity(3);


### PR DESCRIPTION
This makes save_as_json more efficient.  It also raises the MSRV to 1.77.0, but libnv-rs doesn't have an official MSRV policy yet.  Also, convert the edition to 2021 and fix a doc test.