### PR TITLE
Better documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ members = [ ".", "libnv-sys" ]
 dev-version-ext = "pre"
 pre-release-hook = ["git-cliff", "-o", "CHANGELOG.md", "--tag", "{{version}}"]
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+  "x86_64-unknown-freebsd",
+  "x86_64-unknown-linux-gnu",
+]
+
 [features]
 default = ["libnv", "nvpair"]
 libnv = ["libnv-sys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 //! [libnv]: https://www.freebsd.org/cgi/man.cgi?query=nv
 //! [nvpair]: https://github.com/zfsonlinux/zfs/tree/master/module/nvpair
 
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 extern crate libc;
 #[macro_use]
 extern crate quick_error;


### PR DESCRIPTION
* On docs.rs, build the docs for the main supported platforms.
* On docs.rs, use doc_auto_cfg to label each module with its required cfg features.