### PR TITLE
Widen bindgen dependency spec

### DIFF
--- a/libnv-sys/Cargo.toml
+++ b/libnv-sys/Cargo.toml
@@ -20,5 +20,5 @@ targets = [
 libc = "0.2.65"
 
 [build-dependencies]
-bindgen = { version = "0.66.1", features=[] }
+bindgen = { version = ">= 0.67.0, < 0.72.0", features=[] }
 regex = "1.6.0"

--- a/libnv-sys/build.rs
+++ b/libnv-sys/build.rs
@@ -18,7 +18,7 @@ fn main() {
         .blocklist_type("__size_t")
         .blocklist_type("__uint64_t")
         .opaque_type("FILE")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Unable to generate bindings")
         .to_string();


### PR DESCRIPTION
To allow downstream consumers to build fewer versions of bindgen