### PR TITLE
Fix the build with -Zdirect-minimal-versions

### DIFF
--- a/libnv-sys/Cargo.toml
+++ b/libnv-sys/Cargo.toml
@@ -21,5 +21,5 @@ targets = [
 libc = "0.2.65"
 
 [build-dependencies]
-bindgen = { version = ">= 0.67.0, < 0.73.0", features=[] }
+bindgen = { version = ">= 0.69.0, < 0.73.0", features=[] }
 regex = "1.6.0"


### PR DESCRIPTION
I'm not sure why this worked before.  Probably something else in the dependency tree prevent bindgen from being downgraded all the way? Or maybe bindgen 0.67 worked, but bindgen 0.68 didn't, and the latter has now been yanked?