### PR TITLE
Narrow the range of bindgen versions allowed

### DIFF
--- a/libnv-sys/Cargo.toml
+++ b/libnv-sys/Cargo.toml
@@ -21,5 +21,5 @@ targets = [
 libc = "0.2.65"
 
 [build-dependencies]
-bindgen = { version = ">= 0.67.0, < 0.73.0", features=[] }
+bindgen = { version = ">= 0.69.0, < 0.73.0", features=[] }
 regex = "1.6.0"


### PR DESCRIPTION
I'm not sure why this crate built before, but it sure doesn't build now with bindgen less than 0.69 .