### PR TITLE
Fix the build on 32-bit FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,18 @@ jobs:
       matrix:
         include:
           - freebsd_version: "15.0"
+            target: x86_64-unknown-freebsd
             rust_version: nightly
+            zflags: ""
           - freebsd_version: "14.4"
+            target: x86_64-unknown-freebsd
             rust_version: stable
-    name: FreeBSD ${{ matrix.freebsd_version }} ${{ matrix.rust_version }}
+            zflags: ""
+          - freebsd_version: "14.4"
+            target: i686-unknown-freebsd
+            rust_version: nightly
+            zflags: "-Z build-std"
+    name: FreeBSD ${{ matrix.freebsd_version }} ${{ matrix.target }} ${{ matrix.rust_version }}
     steps:
       - uses: actions/checkout@v6
       - name: Start VM
@@ -32,33 +40,39 @@ jobs:
         run: |
           pkg install -y curl
           fetch https://sh.rustup.rs -o rustup.sh
-          sh rustup.sh -y --profile=minimal --default-toolchain ${{ matrix.rust_version }}
+          sh rustup.sh -y --default-toolchain ${{ matrix.rust_version }}
+      - name: Install rust-src
+        if: matrix.zflags != ''
+        shell: freebsd {0}
+        run: |
+          . $HOME/.cargo/env
+          rustup component add rust-src
       - name: Build
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cargo build --all-features
+          cargo build ${{ matrix.zflags }} --all-features
       - name: Test
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cargo test --all-features
+          cargo test ${{ matrix.zflags }} --all-features
       - name: Clippy
-        if: matrix.rust_version == 'nightly'
+        if: matrix.rust_version == 'nightly' && matrix.zflags == ''
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
           rustup component add clippy
           cargo clippy --all-targets --all-features -- -D warnings
       - name: Hack
-        if: matrix.rust_version == 'nightly'
+        if: matrix.rust_version == 'nightly' && matrix.zflags == ''
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
           curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-freebsd.tar.gz | tar xzf - -C ~/.cargo/bin
           cargo hack check --feature-powerset
       - name: Minver
-        if: matrix.rust_version == 'nightly'
+        if: matrix.rust_version == 'nightly' && matrix.zflags == ''
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - ReleaseDAte
+
+### Bug Fixes
+
+- Fixed the build on 32-bit FreeBSD (#69)
+
 ## [0.5.0] - 2026-06-14
 
 ### Features

--- a/libnv-sys/bindgen/bindgen.sh
+++ b/libnv-sys/bindgen/bindgen.sh
@@ -2,14 +2,19 @@
 
 CRATEDIR=`dirname $0`/..
 
+rm ${CRATEDIR}/src/ffi.rs
 bindgen --formatter=none \
 	--allowlist-function 'nvlist_.*' \
 	--allowlist-function 'FreeBSD_nvlist_.*' \
+	--blocklist-function 'FreeBSD_nvlist_add_stringv' \
 	--allowlist-type nvlist_t \
 	--allowlist-type FreeBSD_nvlist_t \
 	--blocklist-type size_t \
 	--blocklist-type __size_t \
+	--blocklist-type va_list \
 	--blocklist-type __uint64_t \
+	--blocklist-type __builtin_va_list \
+	--blocklist-type __va_list_tag \
 	--opaque-type FILE \
 	/usr/include/sys/nv.h |
 sed -E	-e 's/pub fn FreeBSD_([a-zA-Z0-9_]+)/#[link_name = \"FreeBSD_\1\"]pub fn \1/g' \

--- a/libnv-sys/src/fakes.rs
+++ b/libnv-sys/src/fakes.rs
@@ -20,10 +20,7 @@ extern "C" {
         _: ::std::os::raw::c_int,
     );
     pub fn nvlist_size(_: *const FreeBSD_nvlist_t) -> usize;
-    pub fn nvlist_pack(
-        _: *const FreeBSD_nvlist_t,
-        _: *mut usize,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn nvlist_pack(_: *const FreeBSD_nvlist_t, _: *mut usize) -> *mut ::std::os::raw::c_void;
     pub fn nvlist_unpack(
         _: *const ::std::os::raw::c_void,
         _: usize,

--- a/libnv-sys/src/ffi.rs
+++ b/libnv-sys/src/ffi.rs
@@ -17,7 +17,6 @@ pub struct FreeBSD_nvlist {
 }
 pub type FreeBSD_nvlist_t = nvlist_t;
 pub type nvlist_t = FreeBSD_nvlist;
-pub type va_list = __builtin_va_list;
 pub type FILE = __BindgenOpaqueArray<u64, 39usize>;
 unsafe extern "C" {
     #[link_name = "FreeBSD_nvlist_create"]
@@ -258,15 +257,6 @@ unsafe extern "C" {
         name: *const ::std::os::raw::c_char,
         valuefmt: *const ::std::os::raw::c_char,
         ...
-    );
-}
-unsafe extern "C" {
-    #[link_name = "FreeBSD_nvlist_add_stringv"]
-    pub fn nvlist_add_stringv(
-        nvl: *mut FreeBSD_nvlist_t,
-        name: *const ::std::os::raw::c_char,
-        valuefmt: *const ::std::os::raw::c_char,
-        valueap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -702,25 +692,3 @@ unsafe extern "C" {
         name: *const ::std::os::raw::c_char,
     );
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __va_list_tag {
-    pub gp_offset: ::std::os::raw::c_uint,
-    pub fp_offset: ::std::os::raw::c_uint,
-    pub overflow_arg_area: *mut ::std::os::raw::c_void,
-    pub reg_save_area: *mut ::std::os::raw::c_void,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __va_list_tag"][::std::mem::size_of::<__va_list_tag>() - 24usize];
-    ["Alignment of __va_list_tag"][::std::mem::align_of::<__va_list_tag>() - 8usize];
-    ["Offset of field: __va_list_tag::gp_offset"]
-        [::std::mem::offset_of!(__va_list_tag, gp_offset) - 0usize];
-    ["Offset of field: __va_list_tag::fp_offset"]
-        [::std::mem::offset_of!(__va_list_tag, fp_offset) - 4usize];
-    ["Offset of field: __va_list_tag::overflow_arg_area"]
-        [::std::mem::offset_of!(__va_list_tag, overflow_arg_area) - 8usize];
-    ["Offset of field: __va_list_tag::reg_save_area"]
-        [::std::mem::offset_of!(__va_list_tag, reg_save_area) - 16usize];
-};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "stable"
-profile = "default"
-components = ["rust-src"]


### PR DESCRIPTION
It was failing because the pregenerated bindgen layouts assumed 64-bit architectures.  Fortuneately, bindgen's layout tests caught the discrepancy.  But the only structure with a wordsize sensitive layout was only used by a function that isn't even used by the libnv crate.  So simply remove it from the libnv-sys bindings.

Also, add i686-unknown-freebsd to the CI tests.

Fixes #68